### PR TITLE
Rename `gen-key` and improve docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,13 +67,13 @@ DREAM_INTERFACE env)
 -s SECRET, --secret=SECRET (absent DREAM_SECRET env)
     a key to be used for cryptographic operations, such as signing CSRF
     tokens. By default, a random secret is generated on each call to
-    Dream.run. For production, generate a key with gen-key and load it
+    Dream.run. For production, generate a key with gen-secret and load it
     from file. A medium-sized Web app serving 1000 fresh encrypted
     cookies per second should rotate keys about once a year. See
     argument --old-secrets) below for key rotation.
 ```
 
-Or as environmnet variables:
+Or as environmental variables:
 
 ```
 DREAM_CERTIFICATE_FILE
@@ -113,11 +113,27 @@ DREAM_VERBOSITY
     See option --verbosity.
 ```
 
+Note that in order for the command-line arguments to be recognized by Dream, and not by the build tool, it is necessary to prepend them with a double dash:
+
+```sh
+# esy
+npx esy start -- -p 9000
+# dune
+dune exec ./main.ml -- -p 9000
+```
+
 ## Additional commands
 
 The following subcommands are provided in the generated CLI for convenience:
 
-- `gen-key` - Generate a random secret key.
+- `gen-secret` - Generate a random secret.
+
+```sh
+# esy
+npx esy start gen-secret
+# dune
+dune exec ./main.ml gen-secret
+```
 
 ## Custom commands
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ DREAM_INTERFACE env)
     argument --old-secrets) below for key rotation.
 ```
 
-Or as environmental variables:
+Or as environment variables:
 
 ```
 DREAM_CERTIFICATE_FILE
@@ -117,9 +117,9 @@ Note that in order for the command-line arguments to be recognized by Dream, and
 
 ```sh
 # esy
-npx esy start -- -p 9000
+npx esy run <my_binary> -- -p 9000
 # dune
-dune exec ./main.ml -- -p 9000
+dune exec <my_binary> -- -p 9000
 ```
 
 ## Additional commands
@@ -130,9 +130,9 @@ The following subcommands are provided in the generated CLI for convenience:
 
 ```sh
 # esy
-npx esy start gen-secret
+npx esy run <my_binary> gen-secret
 # dune
-dune exec ./main.ml gen-secret
+dune exec <my_binary> gen-secret
 ```
 
 ## Custom commands

--- a/lib/cmd_gen_key.ml
+++ b/lib/cmd_gen_key.ml
@@ -7,7 +7,7 @@ let run len =
 
 open Cmdliner
 
-let doc = "Generate a random secret key"
+let doc = "Generate a random secret"
 
 let sdocs = Manpage.s_common_options
 
@@ -20,7 +20,7 @@ let man =
   ; `P "$(tname) will generate a random key and encode it as a Base64 string."
   ]
 
-let info = Term.info "gen-key" ~doc ~sdocs ~exits ~man ~man_xrefs
+let info = Term.info "gen-secret" ~doc ~sdocs ~exits ~man ~man_xrefs
 
 let term =
   let open Common.Syntax in

--- a/lib/cmd_run.ml
+++ b/lib/cmd_run.ml
@@ -120,7 +120,7 @@ let term
       let doc =
         "a key to be used for cryptographic operations, such as signing CSRF \
          tokens. By default, a random secret is generated on each call to \
-         Dream.run. For production, generate a key with $(b,gen-key)\n\
+         Dream.run. For production, generate a key with $(b,gen-secret)\n\
          and load it from file. A medium-sized Web app serving 1000 fresh \
          encrypted cookies per second should rotate keys about once a year. \
          See argument $(b,--old-secrets)) below for key rotation."


### PR DESCRIPTION
Improve README.md with examples and a clarification about how to pass
command line arguments